### PR TITLE
feat(admin): add student data enrichment via school CSV import

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Sequence, Optional, List
 
-from sqlalchemy import insert, select, update, delete
+from sqlalchemy import insert, select, update, delete, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from passlib.context import CryptContext
 
-from .models import User, Visit, DashboardUser, DashboardRoleEnum
+from .models import User, Visit, DashboardUser, DashboardRoleEnum, StudentEnrichment
 from .schemas import ReportIn, UserInfoIn, VisitIn
 
 # Import password functions from utils to avoid duplication
@@ -38,6 +38,25 @@ async def upsert_user(db: AsyncSession, info: UserInfoIn) -> int:
 
     result = await db.execute(stmt)
     user_id = result.scalar_one()
+
+    # Apply student enrichment if available (for Chrome extension users who only send email)
+    email = info.Email or info.Username or ""
+    if "@schools.vic.edu.au" in email:
+        login = email.split("@")[0].upper()
+        enrichment_result = await db.execute(
+            select(StudentEnrichment).where(StudentEnrichment.login == login)
+        )
+        enrichment = enrichment_result.scalar_one_or_none()
+        if enrichment:
+            await db.execute(
+                update(User).where(User.id == user_id).values(
+                    first_name=enrichment.first_name,
+                    last_name=enrichment.last_name,
+                    display_name=enrichment.display_name,
+                    homegroup=enrichment.homegroup,
+                )
+            )
+
     return user_id
 
 
@@ -104,4 +123,40 @@ async def delete_dashboard_user(db: AsyncSession, username: str) -> bool:
     """Delete dashboard user."""
     stmt = delete(DashboardUser).where(DashboardUser.username == username)
     result = await db.execute(stmt)
-    return result.rowcount > 0 
+    return result.rowcount > 0
+
+
+# Student Enrichment Operations
+
+async def upsert_student_enrichments(db: AsyncSession, rows: list) -> int:
+    """Upsert student enrichment records. Returns count of rows imported."""
+    if not rows:
+        return 0
+    stmt = pg_insert(StudentEnrichment).values(rows).on_conflict_do_update(
+        index_elements=[StudentEnrichment.login],
+        set_=dict(
+            first_name=pg_insert(StudentEnrichment).excluded.first_name,
+            last_name=pg_insert(StudentEnrichment).excluded.last_name,
+            display_name=pg_insert(StudentEnrichment).excluded.display_name,
+            homegroup=pg_insert(StudentEnrichment).excluded.homegroup,
+            imported_at=pg_insert(StudentEnrichment).excluded.imported_at,
+        ),
+    )
+    await db.execute(stmt)
+    return len(rows)
+
+
+async def apply_enrichment_to_existing_users(db: AsyncSession) -> int:
+    """Bulk-update existing users with enrichment data. Returns count of updated rows."""
+    result = await db.execute(text("""
+        UPDATE users u
+        SET
+            first_name   = se.first_name,
+            last_name    = se.last_name,
+            display_name = se.display_name,
+            homegroup    = se.homegroup
+        FROM student_enrichments se
+        WHERE UPPER(SPLIT_PART(u.email, '@', 1)) = se.login
+           OR UPPER(SPLIT_PART(u.username, '@', 1)) = se.login
+    """))
+    return result.rowcount 

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ from .schemas import ReportIn, DashboardUserCreate, DashboardUserUpdate, Dashboa
 from .crud import (
     upsert_user, bulk_insert_visits, get_dashboard_users, get_dashboard_user_by_username,
     create_dashboard_user, update_dashboard_user_password, update_dashboard_user_role,
-    delete_dashboard_user
+    delete_dashboard_user, upsert_student_enrichments, apply_enrichment_to_existing_users
 )
 from .models import DashboardUser, DashboardRoleEnum, User, Visit
 from .utils import encrypt_secure_config, decrypt_secure_config, verify_password, get_password_hash
@@ -754,6 +754,73 @@ charlie.dev,DevPass654,user"""
             "Content-Disposition": "attachment; filename=users_import_example.csv"
         }
     )
+
+
+@app.post("/api/admin/enrich-students")
+async def admin_enrich_students(
+    request: Request,
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+):
+    """Import school CSV export to enrich student user records (admin only).
+    Only stores: login, firstName, lastName, displayName, studClass.
+    All other columns are ignored.
+    """
+    await require_admin(request, db)
+
+    if not file.filename.endswith(".csv"):
+        raise HTTPException(status_code=400, detail="File must be a CSV")
+
+    try:
+        content = await file.read()
+        csv_content = content.decode("utf-8-sig")  # handle BOM if present
+        csv_reader = csv.DictReader(io.StringIO(csv_content))
+
+        required_cols = {"login", "firstName", "lastName", "displayName", "studClass"}
+        if not required_cols.issubset(set(csv_reader.fieldnames or [])):
+            raise HTTPException(
+                status_code=400,
+                detail=f"CSV must contain columns: {', '.join(sorted(required_cols))}",
+            )
+
+        rows = []
+        skipped = 0
+        now = datetime.now(timezone.utc)
+
+        for row in csv_reader:
+            login = (row.get("login") or "").strip().upper()
+            if not login:
+                skipped += 1
+                continue
+            rows.append(
+                dict(
+                    login=login,
+                    first_name=(row.get("firstName") or "").strip() or None,
+                    last_name=(row.get("lastName") or "").strip() or None,
+                    display_name=(row.get("displayName") or "").strip() or None,
+                    homegroup=(row.get("studClass") or "").strip() or None,
+                    imported_at=now,
+                )
+            )
+
+        imported = await upsert_student_enrichments(db, rows)
+        users_updated = await apply_enrichment_to_existing_users(db)
+        await db.commit()
+
+        return {
+            "success": True,
+            "imported": imported,
+            "users_updated": users_updated,
+            "skipped": skipped,
+        }
+
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
+    except HTTPException:
+        raise
+    except Exception as e:
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=f"Import failed: {str(e)}")
 
 
 # Serve Bootstrap dashboard -------------------------------------------

--- a/backend/models.py
+++ b/backend/models.py
@@ -40,6 +40,18 @@ class Visit(Base):
     user = relationship("User", back_populates="visits")
 
 
+class StudentEnrichment(Base):
+    __tablename__ = "student_enrichments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    login = Column(String, unique=True, nullable=False, index=True)  # e.g. "TJAMA2"
+    first_name = Column(String)
+    last_name = Column(String)
+    display_name = Column(String)
+    homegroup = Column(String)
+    imported_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+
 class DashboardRoleEnum(str, PyEnum):
     admin = "admin"
     user = "user"

--- a/backend/templates/admin.html
+++ b/backend/templates/admin.html
@@ -100,6 +100,22 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="card mt-3">
+                            <div class="card-header bg-success text-white">
+                                <h6 class="mb-0"><i class="fas fa-id-card me-2"></i>Student Data Enrichment</h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <label for="enrichmentFile" class="form-label">School Export CSV</label>
+                                    <input type="file" class="form-control" id="enrichmentFile" accept=".csv" required>
+                                    <div class="form-text">Export from your central system. Only login, name, and class data will be stored.</div>
+                                </div>
+                                <button type="button" class="btn btn-success w-100" onclick="importStudentEnrichment()">
+                                    <i class="fas fa-cloud-upload-alt me-2"></i>Import &amp; Enrich
+                                </button>
+                                <div id="enrichmentResult" class="mt-3" style="display: none;"></div>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="col-md-8">
@@ -532,6 +548,50 @@
             } finally {
                 uploadBtn.innerHTML = originalText;
                 uploadBtn.disabled = false;
+            }
+        }
+
+        async function importStudentEnrichment() {
+            const fileInput = document.getElementById('enrichmentFile');
+            const file = fileInput.files[0];
+            if (!file) return showAdminMessage('Please select a CSV file to upload', 'warning');
+            if (!file.name.endsWith('.csv')) return showAdminMessage('Please select a CSV file', 'warning');
+
+            const formData = new FormData();
+            formData.append('file', file);
+
+            const btn = document.querySelector('button[onclick="importStudentEnrichment()"]');
+            const originalText = btn.innerHTML;
+            const resultDiv = document.getElementById('enrichmentResult');
+            resultDiv.style.display = 'none';
+
+            try {
+                btn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Importing...';
+                btn.disabled = true;
+
+                const response = await fetch('/api/admin/enrich-students', { method: 'POST', body: formData });
+                const result = await response.json();
+                if (!response.ok) throw new Error(result.detail || 'Import failed');
+
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = `
+                    <div class="alert alert-success mb-0">
+                        <i class="fas fa-check-circle me-2"></i>
+                        <strong>Import complete</strong><br>
+                        <small>
+                            ${result.imported.toLocaleString()} records imported &bull;
+                            ${result.users_updated.toLocaleString()} existing users enriched
+                            ${result.skipped > 0 ? ` &bull; ${result.skipped} rows skipped` : ''}
+                        </small>
+                    </div>`;
+                fileInput.value = '';
+            } catch (error) {
+                console.error('Error importing enrichment data:', error);
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = `<div class="alert alert-danger mb-0"><i class="fas fa-exclamation-triangle me-2"></i>${error.message}</div>`;
+            } finally {
+                btn.innerHTML = originalText;
+                btn.disabled = false;
             }
         }
 


### PR DESCRIPTION
Adds an admin-only CSV import flow that enriches Chrome extension user records with name and homegroup data from the school's central system.

- New `student_enrichments` table stores only login, name, and class fields — all other CSV columns are discarded
- CSV matched via `login@schools.vic.edu.au` against user email/username
- Bulk-updates all existing matching users on import
- `upsert_user` automatically applies enrichment for future Chrome extension reports at ingest time
- New POST /api/admin/enrich-students endpoint (admin only)
- New "Student Data Enrichment" card in the Admin UI