### PR TITLE
refactor: deduplicate query filters and CSV validation logic

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -48,6 +48,61 @@ def configure(tpl: Jinja2Templates, secureconfig_path: str) -> None:
     SECURECONFIG_PATH = secureconfig_path
 
 
+async def _read_csv_upload(
+    file: UploadFile,
+    max_bytes: int,
+    required_headers: set[str],
+    encoding: str = "utf-8",
+) -> csv.DictReader:
+    """Read, size-check, decode, and validate headers of an uploaded CSV file."""
+    if not file.filename or not file.filename.endswith(".csv"):
+        raise HTTPException(status_code=400, detail="File must be a CSV")
+    content = await file.read()
+    if len(content) > max_bytes:
+        max_mb = max_bytes // (1024 * 1024)
+        raise HTTPException(status_code=400, detail=f"CSV file too large (max {max_mb} MB)")
+    try:
+        csv_content = content.decode(encoding)
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
+    reader = csv.DictReader(io.StringIO(csv_content))
+    if not required_headers.issubset(set(reader.fieldnames or [])):
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV must contain headers: {', '.join(sorted(required_headers))}",
+        )
+    return reader
+
+
+def _validate_bulk_import_rows(csv_reader: csv.DictReader) -> tuple[list[tuple], list[str]]:
+    """Validate rows from a bulk-user-import CSV; return (valid_rows, errors)."""
+    errors: list[str] = []
+    usernames_seen: list[str] = []
+    valid_rows: list[tuple] = []
+    for row_num, row in enumerate(csv_reader, start=2):
+        username = row.get("username", "").strip()
+        password = row.get("password", "").strip()
+        role = row.get("role", "").strip().lower()
+        if not username or not password or not role:
+            errors.append(f"Row {row_num}: Missing required fields")
+            continue
+        if len(username) < 3 or len(username) > 50:
+            errors.append(f"Row {row_num}: Username must be 3-50 characters")
+            continue
+        if len(password) < 6 or len(password) > 72:
+            errors.append(f"Row {row_num}: Password must be 6-72 characters")
+            continue
+        if role not in ("admin", "user"):
+            errors.append(f"Row {row_num}: Role must be 'admin' or 'user'")
+            continue
+        if username in usernames_seen:
+            errors.append(f"Row {row_num}: Duplicate username '{username}' in CSV")
+            continue
+        usernames_seen.append(username)
+        valid_rows.append((row_num, username, password, role))
+    return valid_rows, errors
+
+
 # ── Dashboard user CRUD ──────────────────────────────────────────────────
 
 @router.post("/create-admin-emergency")
@@ -134,50 +189,11 @@ async def admin_bulk_import_users(
     """Bulk import dashboard users from CSV file (admin only)."""
     await require_admin(request, db)
 
-    if not file.filename or not file.filename.endswith(".csv"):
-        raise HTTPException(status_code=400, detail="File must be a CSV")
-
     try:
-        content = await file.read()
-        # Reject excessively large CSV files (5 MB limit)
-        if len(content) > 5 * 1024 * 1024:
-            raise HTTPException(status_code=400, detail="CSV file too large (max 5 MB)")
-        csv_content = content.decode("utf-8")
-        csv_reader = csv.DictReader(io.StringIO(csv_content))
+        csv_reader = await _read_csv_upload(file, 5 * 1024 * 1024, {"username", "password", "role"})
+        valid_rows, errors = _validate_bulk_import_rows(csv_reader)
 
-        required_headers = {"username", "password", "role"}
-        if not required_headers.issubset(set(csv_reader.fieldnames or [])):
-            raise HTTPException(status_code=400, detail=f"CSV must contain headers: {', '.join(required_headers)}")
-
-        created_users: list[dict] = []
-        errors: list[str] = []
-        usernames_to_check: list[str] = []
-        valid_rows: list[tuple] = []
-
-        for row_num, row in enumerate(csv_reader, start=2):
-            username = row.get("username", "").strip()
-            password = row.get("password", "").strip()
-            role = row.get("role", "").strip().lower()
-
-            if not username or not password or not role:
-                errors.append(f"Row {row_num}: Missing required fields")
-                continue
-            if len(username) < 3 or len(username) > 50:
-                errors.append(f"Row {row_num}: Username must be 3-50 characters")
-                continue
-            if len(password) < 6 or len(password) > 72:
-                errors.append(f"Row {row_num}: Password must be 6-72 characters")
-                continue
-            if role not in ("admin", "user"):
-                errors.append(f"Row {row_num}: Role must be 'admin' or 'user'")
-                continue
-            if username in usernames_to_check:
-                errors.append(f"Row {row_num}: Duplicate username '{username}' in CSV")
-                continue
-
-            usernames_to_check.append(username)
-            valid_rows.append((row_num, username, password, role))
-
+        usernames_to_check = [row[1] for row in valid_rows]
         existing_usernames: set[str] = set()
         if usernames_to_check:
             result = await db.execute(
@@ -185,6 +201,7 @@ async def admin_bulk_import_users(
             )
             existing_usernames = set(result.scalars().all())
 
+        created_users: list[dict] = []
         for row_num, username, password, role in valid_rows:
             if username in existing_usernames:
                 errors.append(f"Row {row_num}: Username '{username}' already exists")
@@ -209,8 +226,6 @@ async def admin_bulk_import_users(
             "errors": errors,
         }
 
-    except UnicodeDecodeError:
-        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
     except HTTPException:
         raise
     except Exception as e:
@@ -237,20 +252,13 @@ async def admin_enrich_students(
     """Import school CSV export to enrich student user records (admin only)."""
     await require_admin(request, db)
 
-    if not file.filename or not file.filename.endswith(".csv"):
-        raise HTTPException(status_code=400, detail="File must be a CSV")
-
     try:
-        content = await file.read()
-        # Reject excessively large CSV files (10 MB limit)
-        if len(content) > 10 * 1024 * 1024:
-            raise HTTPException(status_code=400, detail="CSV file too large (max 10 MB)")
-        csv_content = content.decode("utf-8-sig")
-        csv_reader = csv.DictReader(io.StringIO(csv_content))
-
-        required_cols = {"login", "firstName", "lastName", "displayName", "studClass"}
-        if not required_cols.issubset(set(csv_reader.fieldnames or [])):
-            raise HTTPException(status_code=400, detail=f"CSV must contain columns: {', '.join(sorted(required_cols))}")
+        csv_reader = await _read_csv_upload(
+            file,
+            10 * 1024 * 1024,
+            {"login", "firstName", "lastName", "displayName", "studClass"},
+            encoding="utf-8-sig",
+        )
 
         rows = []
         skipped = 0
@@ -276,8 +284,6 @@ async def admin_enrich_students(
 
         return {"success": True, "imported": imported, "users_updated": users_updated, "skipped": skipped}
 
-    except UnicodeDecodeError:
-        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -58,6 +58,28 @@ router = APIRouter()
 templates: Jinja2Templates = None  # type: ignore[assignment]
 
 
+def _apply_homegroup_cutoff(q, homegroup: Optional[str], cutoff):
+    """Apply homegroup and time-cutoff WHERE clauses to a query."""
+    if homegroup:
+        q = q.where(User.homegroup == homegroup)
+    if cutoff:
+        q = q.where(Visit.visit_time >= cutoff)
+    return q
+
+
+def _apply_user_search(q, search: Optional[str]):
+    """Apply username/display-name/email/homegroup text search to a query."""
+    if search:
+        pattern = f"%{search.lower()}%"
+        q = q.where(
+            func.lower(User.username).like(pattern)
+            | func.lower(func.coalesce(User.display_name, "")).like(pattern)
+            | func.lower(func.coalesce(User.email, "")).like(pattern)
+            | func.lower(func.coalesce(User.homegroup, "")).like(pattern)
+        )
+    return q
+
+
 def configure(tpl: Jinja2Templates) -> None:
     global templates
     templates = tpl
@@ -108,18 +130,8 @@ async def reports_all(
     )
 
     # Filters
-    if homegroup:
-        selectable = selectable.where(User.homegroup == homegroup)
-    if cutoff:
-        selectable = selectable.where(Visit.visit_time >= cutoff)
-    if search:
-        pattern = f"%{search.lower()}%"
-        selectable = selectable.where(
-            func.lower(User.username).like(pattern)
-            | func.lower(func.coalesce(User.display_name, "")).like(pattern)
-            | func.lower(func.coalesce(User.email, "")).like(pattern)
-            | func.lower(func.coalesce(User.homegroup, "")).like(pattern)
-        )
+    selectable = _apply_homegroup_cutoff(selectable, homegroup, cutoff)
+    selectable = _apply_user_search(selectable, search)
 
     selectable = selectable.group_by(User.id).order_by(User.username)
 
@@ -129,18 +141,8 @@ async def reports_all(
         .select_from(User)
         .outerjoin(Visit, Visit.user_id == User.id)
     )
-    if homegroup:
-        count_q = count_q.where(User.homegroup == homegroup)
-    if cutoff:
-        count_q = count_q.where(Visit.visit_time >= cutoff)
-    if search:
-        pattern = f"%{search.lower()}%"
-        count_q = count_q.where(
-            func.lower(User.username).like(pattern)
-            | func.lower(func.coalesce(User.display_name, "")).like(pattern)
-            | func.lower(func.coalesce(User.email, "")).like(pattern)
-            | func.lower(func.coalesce(User.homegroup, "")).like(pattern)
-        )
+    count_q = _apply_homegroup_cutoff(count_q, homegroup, cutoff)
+    count_q = _apply_user_search(count_q, search)
     total_count = (await db.execute(count_q)).scalar() or 0
 
     # Paginate
@@ -227,10 +229,7 @@ async def search_website(
         .where(search_filter)
         .order_by(text("rank DESC"), Visit.visit_time.desc())
     )
-    if homegroup:
-        query = query.where(User.homegroup == homegroup)
-    if cutoff:
-        query = query.where(Visit.visit_time >= cutoff)
+    query = _apply_homegroup_cutoff(query, homegroup, cutoff)
 
     # Count
     count_q = (
@@ -239,10 +238,7 @@ async def search_website(
         .join(User, Visit.user_id == User.id)
         .where(search_filter)
     )
-    if homegroup:
-        count_q = count_q.where(User.homegroup == homegroup)
-    if cutoff:
-        count_q = count_q.where(Visit.visit_time >= cutoff)
+    count_q = _apply_homegroup_cutoff(count_q, homegroup, cutoff)
     total_count = (await db.execute(count_q)).scalar() or 0
 
     # Unique users
@@ -252,10 +248,7 @@ async def search_website(
         .join(User, Visit.user_id == User.id)
         .where(Visit.url.ilike(f"%{url}%"))
     )
-    if homegroup:
-        unique_q = unique_q.where(User.homegroup == homegroup)
-    if cutoff:
-        unique_q = unique_q.where(Visit.visit_time >= cutoff)
+    unique_q = _apply_homegroup_cutoff(unique_q, homegroup, cutoff)
     unique_users_count = (await db.execute(unique_q)).scalar() or 0
 
     # Paginate


### PR DESCRIPTION
Extract _apply_homegroup_cutoff and _apply_user_search helpers in reports.py to eliminate 6 duplicated filter blocks across reports_all and search_website. Extract _read_csv_upload and _validate_bulk_import_rows helpers in admin.py, consolidating shared CSV file-handling code from admin_bulk_import_users and admin_enrich_students.